### PR TITLE
Silence observed deprecation warnings

### DIFF
--- a/cto10r/mining.py
+++ b/cto10r/mining.py
@@ -272,7 +272,7 @@ def mine_rules(cands: pd.DataFrame, events: pd.DataFrame, cfg: dict):
 
         months_with_lift = 0
         if "ym" in sub.columns:
-            bym = sub.groupby("ym").agg(
+            bym = sub.groupby("ym", observed=False, sort=False).agg(
                 n=("is_win", "size"),
                 win=("is_win", "sum"),
                 loss=("is_loss", "sum"),

--- a/cto10r/ml.py
+++ b/cto10r/ml.py
@@ -99,7 +99,7 @@ def _hist_by_month(s: pd.Series, edges: np.ndarray, months: pd.Series) -> Dict[s
     if len(s) == 0:
         return res
     months = months.reindex(s.index)
-    for m, sub in s.groupby(months):
+    for m, sub in s.groupby(months, observed=False):
         sub = pd.to_numeric(sub, errors="coerce").dropna()
         if len(sub) == 0:
             continue
@@ -261,7 +261,7 @@ def _choose_bins_for_feature(
         if PREF_MONO and len(np.unique(idx_fit)) > 1:
             means = (
                 pd.DataFrame({"bin": idx_fit, "y": y_fit})
-                .groupby("bin")["y"]
+                .groupby("bin", observed=False)["y"]
                 .mean()
                 .fillna(0.0)
                 .to_numpy()


### PR DESCRIPTION
## Summary
- add explicit observed=False and sort=False to rule-mining monthly aggregations to preserve existing semantics
- ensure monthly histogram computations and monotonicity checks use observed=False to avoid future deprecation warnings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0ba22b4b8832bbf1b7adbcd9b77bb